### PR TITLE
Update guides_style_18f to v1.0.4

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,5 +6,5 @@ gem 'rouge'
 gem 'go_script'
 
 group :jekyll_plugins do
-  gem 'guides_style_18f'
+  gem 'guides_style_18f', '~> 1.0.4'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,7 +6,7 @@ GEM
     go_script (0.1.9)
       bundler (~> 1.10)
       safe_yaml (~> 1.0)
-    guides_style_18f (1.0.1)
+    guides_style_18f (1.0.4)
       jekyll
       jekyll_pages_api
       jekyll_pages_api_search
@@ -51,10 +51,10 @@ PLATFORMS
 
 DEPENDENCIES
   go_script
-  guides_style_18f
+  guides_style_18f (~> 1.0.4)
   jekyll
   redcarpet
   rouge
 
 BUNDLED WITH
-   1.12.5
+   1.15.4


### PR DESCRIPTION
This commit updates the version on the guides_style_18f gem which
previously had an out of date version of jQuery.