### PR TITLE
Move parts of the phone screen guide to a public document.

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -42,8 +42,8 @@ navigation:
   url: unconcious-bias/
   internal: true
 - text: Conducting phone screens
-  url: https://docs.google.com/document/d/1La5M7YojZFEc0lvpQZ4Kc7dL8UgssBoJe3FqmmJwmK4/edit#
-  internal: false
+  url: phone-screens/
+  internal: true
 - text: Resume review guide
   url: resume-review/
   internal: true

--- a/_pages/phone-screens.md
+++ b/_pages/phone-screens.md
@@ -1,0 +1,50 @@
+---
+title: Conducting Phone Screens
+---
+
+The goal of a phone screen is to quickly assess a candidate's rough fit for the position we're hiring, and to quickly screen out candidates who will obviously not work out. Broadly, phone screens accomplish two purposes:
+
+1. Make sure the candidate is aware of the unique nature of the job, and is happy to move forward. Working at 18F isn't for everyone: we get paid less, have to deal with more bureaucracy, and face a monumentally difficult task. If candidates aren't up for the mission and challenge, we want to find that out quickly!
+
+2. Quickly screen out candidates who obviously won't work out. Typically this is true for candidates who don't share our values, as that's something that's hard to assess from a resume but can shake out very quickly in a conversation. Occasionally it's about technical fit: a candidate has a resume that passed review, but in talking to them it's clear they want to work on things that don't really match what we do (or the resume made it sound like they did work that they seem to not really have done).
+
+Phone screens are typically performed by the Director of Engineering, or a delegate as apropriate. It's a best practice to have the same person conduct all phone screens for a given hiring cohort.
+
+Most candidates pass the phone screen. It's a rough filter: it can't be used to really qualify a candidate, but it can be used to disqualify. It's also not uncommon for candidates to self-select out after the phone screen. This is particularly true for candidates who are financially-motivated; the GS-scale is well below tech industry norms.
+
+Because phone screens rely heavily on personal judgment, and are inherently less scientific than the full suite of interviews, phone screeners should be especially wary about [correcting for unconscious bias]({{ site.baseurl }}/unconcious-bias/). Remember that we are not only biased, but we're almost never realize that we're being biased. However, when we realize and accept bias, and recognize it, we can be on the lookout for bias and it'll be less likely to unconsciously guide our decisions.
+
+Phone screens are interviews, so it's a good idea to review the [general guidance around interviews]({{ site.baseurl }}/interviews/) before beginning.
+
+Please remember to take notes: they can be very useful to future interviewers.
+
+## Phone screen outline
+
+* Introduction:
+    * Introduce yourself - say a bit about your position, what you do, etc.
+    * Explain the purpose of the phone screen: to ask some basic questions, and make sure there's alignment on the role. Tell the candidate that you'll ask questions for about 25 minutes, and leave the last 5 for them.
+
+* The position:
+    * "What got you interested in 18F?"
+    * Explain the role - what the role does, where it fits into 18F, etc. Ask if the candidate has questions about the role.
+    * Pay scales: ask if the candidate has seen the GS-scales, and if they know the salary for the position. Clarify that, by default, offers will be at Step 1 (i.e. GS-14 Step 1, or GS-15 Step 1), though they may be able to negotiate for a higher step if they can show appropriate experience and salary from previous positions.
+
+* Technical experience:
+    * "If we do go on to a technical interview, what is your preferred programming language?"
+    * Ask about how the candidate considers themselves with regard to the role:
+        * SRE candidates: devops, developer, ops?
+        * Engineer candidates: devops, full stack, back end, front end?
+        * Security candidates: security engineering, security operations, pentesting?
+    * "Are there any other skill sets we should be talking about? Design, testing, juggling?"
+
+* Background and experience:
+    * "Tell me about your background and goals?" Ask follow-up questions here as necessary to ensure you leave the call with a sense of their contributions in past projects and professional goals for the future. Where possible try to touch on:
+        * teamwork and communication
+        * alignment with our core working styles (distributed teams, open source, agile processes)
+        * alignment with our values around diversity and inclusion
+
+* "Do you have any questions for me?"
+
+## What to look for in phone screens
+
+This part's internal; see: [What to look for during a phone screen](https://docs.google.com/document/d/1La5M7YojZFEc0lvpQZ4Kc7dL8UgssBoJe3FqmmJwmK4/edit)


### PR DESCRIPTION
This follows the same split as the interview guides: make the preamble and questions public, leave the answer rubric private.