### PR TITLE
Remove {{ site.baseurl }} from links, they are unnecessary.

### DIFF
--- a/_pages/interviews.md
+++ b/_pages/interviews.md
@@ -6,13 +6,13 @@ This is a guide for interviewers conducting engineering interviews. Everyone who
 
 To sum up:
 
-- [The golden rule: your goal is find a reason not to hire (but don’t be a jerk!)]({{site.baseurl}}/interviews#golden-rule)
-- [Kicking off the interview]({{site.baseurl}}/interviews#kick-off)
-- [Please follow the guides…]({{site.baseurl}}/interviews#please-follow-the-guides)
-- [… but not dogmatically: feel free to dig deep.]({{site.baseurl}}/interviews#dig-deep)
-- [Take good notes: behavioral is best]({{site.baseurl}}/interviews#take-notes)
-- [Submit a written "hire/no-hire" recommendation, with justification]({{site.baseurl}}/interviews#written-recommendation)
-- [If there’s a disaster, considering ending interviews early]({{site.baseurl}}/interviews#pull-the-plug)
+- [The golden rule: your goal is find a reason not to hire (but don’t be a jerk!)](/interviews#golden-rule)
+- [Kicking off the interview](/interviews#kick-off)
+- [Please follow the guides…](/interviews#please-follow-the-guides)
+- [… but not dogmatically: feel free to dig deep.](/interviews#dig-deep)
+- [Take good notes: behavioral is best](/interviews#take-notes)
+- [Submit a written "hire/no-hire" recommendation, with justification](/interviews#written-recommendation)
+- [If there’s a disaster, considering ending interviews early](/interviews#pull-the-plug)
 
 Click each section for more details.
 

--- a/_pages/interviews/consulting-engineer.md
+++ b/_pages/interviews/consulting-engineer.md
@@ -3,7 +3,7 @@ title: Consulting Engineer Interview Guide
 parent: interviews
 ---
 
-*This is a supplement to the [technical engineering interview guide]({{ site.baseurl }}/interviews/engineer/). Please read that guide first. The questions here can be added to the technical interview for Consulting Engineer candidates.*
+*This is a supplement to the [technical engineering interview guide](/interviews/engineer/). Please read that guide first. The questions here can be added to the technical interview for Consulting Engineer candidates.*
 
 ### Consulting Engineer Questions
 

--- a/_pages/interviews/devops.md
+++ b/_pages/interviews/devops.md
@@ -3,7 +3,7 @@ title: DevOps/SRE Interview Guide
 parent: interviews
 ---
 
-*This is a supplement to the [technical engineering interview guide]({{ site.baseurl }}/interviews/engineer/). Please read that guide first. The questions here can be added to the technical interview for Devops/SRE candidates.*
+*This is a supplement to the [technical engineering interview guide](/interviews/engineer/). Please read that guide first. The questions here can be added to the technical interview for Devops/SRE candidates.*
 
 ### DevOps / Infrastructure Engineering Questions
 
@@ -17,6 +17,6 @@ parent: interviews
 
 ### Security Questions
 
-*A question from the [infosec interview guide]({{ site.baseurl }}/interviews/infosec/) that is also applicable to DevOps/SRE candidates.*
+*A question from the [infosec interview guide](/interviews/infosec/) that is also applicable to DevOps/SRE candidates.*
 
 * [“Tell me about a time that you worked with a team to remediate a security issue.”](https://docs.google.com/document/d/1oYmx_93-mq2QrqICCo8SNk8hHmnPPonPA1kg0vhy540/edit#heading=h.1s7pt8lyer05)

--- a/_pages/interviews/engineer.md
+++ b/_pages/interviews/engineer.md
@@ -17,7 +17,7 @@ conclusions and decisions.
 **Remember to be as pleasant and friendly as you can be!** You can deliver
 a demanding interview while being kind and empathetic.
 
-[For more information on interviewing in general, check out the interviewing guide]({{ site.baseurl }}/interviews/).
+[For more information on interviewing in general, check out the interviewing guide](/interviews/).
 
 # Introductory Statement
 
@@ -45,7 +45,7 @@ Since this is a public document, only the questions themselves are published
 here. 18F staff: click through to see follow-ups and good/bad signs in the
 full [engineering interview question bank](https://docs.google.com/document/d/1oYmx_93-mq2QrqICCo8SNk8hHmnPPonPA1kg0vhy540/edit#).
 
-*For DevOps/SRE candidates: don't miss the [DevOps/SRE question supplement]({{ site.baseurl }}/interviews/devops/).*
+*For DevOps/SRE candidates: don't miss the [DevOps/SRE question supplement](/interviews/devops/).*
 
 ## Problem Solving
 

--- a/_pages/phone-screens.md
+++ b/_pages/phone-screens.md
@@ -12,9 +12,9 @@ Phone screens are typically performed by the Director of Engineering, or a deleg
 
 Most candidates pass the phone screen. It's a rough filter: it can't be used to really qualify a candidate, but it can be used to disqualify. It's also not uncommon for candidates to self-select out after the phone screen. This is particularly true for candidates who are financially-motivated; the GS-scale is well below tech industry norms.
 
-Because phone screens rely heavily on personal judgment, and are inherently less scientific than the full suite of interviews, phone screeners should be especially wary about [correcting for unconscious bias]({{ site.baseurl }}/unconcious-bias/). Remember that we are not only biased, but we're almost never realize that we're being biased. However, when we realize and accept bias, and recognize it, we can be on the lookout for bias and it'll be less likely to unconsciously guide our decisions.
+Because phone screens rely heavily on personal judgment, and are inherently less scientific than the full suite of interviews, phone screeners should be especially wary about [correcting for unconscious bias](/unconcious-bias/). Remember that we are not only biased, but we're almost never realize that we're being biased. However, when we realize and accept bias, and recognize it, we can be on the lookout for bias and it'll be less likely to unconsciously guide our decisions.
 
-Phone screens are interviews, so it's a good idea to review the [general guidance around interviews]({{ site.baseurl }}/interviews/) before beginning.
+Phone screens are interviews, so it's a good idea to review the [general guidance around interviews](/interviews/) before beginning.
 
 Please remember to take notes: they can be very useful to future interviewers.
 

--- a/_pages/pre-work.md
+++ b/_pages/pre-work.md
@@ -34,14 +34,14 @@ After reviewing the code, you'll hold your interview with the candidate.
 The focus of the interview should be on their code, how it works,
 why they made the choices they did, and so forth.
 
-When interviewing, please [take notes]({{ site.baseurl }}/interviews/#take-notes),
+When interviewing, please [take notes](/interviews/#take-notes),
 and *note what the candidate says, rather than your impressions* — that will
 help you share behavior reasons for your conclusions and decisions.
 
 **Remember to be as pleasant and friendly as you can be!** You can deliver
 a demanding interview while being kind and empathetic.
 
-[For more information on interviewing in general, check out the interviewing guide]({{ site.baseurl }}/interviews/).
+[For more information on interviewing in general, check out the interviewing guide](/interviews/).
 
 ### Introductory Statement
 

--- a/_pages/resume-review.md
+++ b/_pages/resume-review.md
@@ -9,13 +9,13 @@ candidate, and this guide will help you figure out how to do that.
 
 Each position will come with a scoring rubric (the formal term for this is a "crediting plan"). This is how we get fairness from the process: this guide gives the specific experience and qualifications required for the job, and lets you review resumes against a consistent set of requirements.
 
-Before you begin a review session, [remind yourself to watch out for unconscious bias]({{ site.baseurl }}/unconcious-bias). Humans are not only biased, but we're almost never realize that we're being biased. However, when we recognize and accept bias we can be on the lookout and it'll be less likely to unconsciously guide our decisions.
+Before you begin a review session, [remind yourself to watch out for unconscious bias](/unconcious-bias). Humans are not only biased, but we're almost never realize that we're being biased. However, when we recognize and accept bias we can be on the lookout and it'll be less likely to unconsciously guide our decisions.
 
 ## Crediting plans
 
 Each position comes with a *crediting plan* -- a formal resume review rubric that we use to "score" resumes and separate applications into a set that'll move on to interviews, and a set we'll reject.
 
-See [the list of crediting plans]({{ site.baseurl }}/resume-review/crediting-plans/) for links to all the ones we have for engineering roles, and for convenient single-page checklists you can print out and use while reviewing resumes if you like.
+See [the list of crediting plans](/resume-review/crediting-plans/) for links to all the ones we have for engineering roles, and for convenient single-page checklists you can print out and use while reviewing resumes if you like.
 
 These guides are rather formal, so let's walk through what they look like. The relevant part of the guide for resume review purposes is the "crediting plan". The crediting plan breaks down into several *competencies*, with each competency having several *criteria*. As you review the resume, you're looking for evidence of these criteria. At the end, the application gets scored based on how many of each criteria are demonstrated, according to a scoring guide in the crediting plan. Note that there's a different crediting plan for each GS-level.
 
@@ -29,7 +29,7 @@ Here's what an example bit from a crediting plan could look like for a hypotheti
 > * Cites experience developing leaf-containment devices out of materials such as metal mesh, cloth, plastic drippers, etc.
 > * [And so on ...]
 >
-See [the list of crediting plans]({{ site.baseurl }}/resume-review/crediting-plans/) for our current active crediting plans, which'll have more domain-specific examples.
+See [the list of crediting plans](/resume-review/crediting-plans/) for our current active crediting plans, which'll have more domain-specific examples.
 
 So, as you review the resume, you'll be looking for evidence of the things cited in the "criteria for job readiness" section: specific programming languages, relational databases, source control, etc. The crediting plan will tell you have to "score" that section.
 
@@ -53,7 +53,7 @@ When you look at a resume, look at the following things, in this order:
 
 This order’s deliberate: the first couple items are quick, and will help "orient" you to the candidate's overall experience, and help focus where you look for the rest. \#2 is the hardest, and will reveal the most detail. The last is least important, and you can skip it if you've already got a clearly qualified applicant. But for those on the edge, these parts can add a bit of extra experience that pushes someone over.
 
-Remember that you’re reviewing a candidate’s entire submission package, which’ll include a resume and some Q&A, and possibly a cover letter and other links (e.g. to LinkedIn, a Github profile, etc). Make sure to scan the whole package for info that’s there, but maybe not on the cover letter. (But see [correcting for unconscious bias]({{ site.baseurl }}/unconcious-bias) for an important note about avoiding social media).
+Remember that you’re reviewing a candidate’s entire submission package, which’ll include a resume and some Q&A, and possibly a cover letter and other links (e.g. to LinkedIn, a Github profile, etc). Make sure to scan the whole package for info that’s there, but maybe not on the cover letter. (But see [correcting for unconscious bias](/unconcious-bias) for an important note about avoiding social media).
 
 You’ll want to have the crediting plan open in front of you as you proceed. You may want to print out the single-page checklist for the relevant position and grade level, and use it to mark off experience as you go.
 


### PR DESCRIPTION
It may have been needed in the past when this site wasn't running on its own domain?
Tests for active links pass locally.

Carter: I was conflating two issues earlier re: 1) linking to page anchors with `#`, and 2) using `{{ site.baseurl }}`.  The first issue is still a thing, but we can just lose all of the site.baseurls.  So, you were right in the first place :)

Thanks Fureigh for pointing out `basurl`!  That helped me figure it out :)