### PR TITLE
Small wording fix to Pre-work page

### DIFF
--- a/_pages/pre-work.md
+++ b/_pages/pre-work.md
@@ -141,7 +141,7 @@ discuss. This is subject to a few conditions:
 [coding problems developed by Ad Hoc](https://homework.adhoc.team),
 and add a few extra rules and restrictions of our own:
 
-- Choose from one of these three exercises, and only complete a single exercise:
+- Choose from one of these exercises, and only complete a single exercise:
     - [https://homework.adhoc.team/fetch/](https://homework.adhoc.team/fetch/)
     - [https://homework.adhoc.team/hhbuilder/](https://homework.adhoc.team/hhbuilder/)
     - [https://homework.adhoc.team/slcsp/](https://homework.adhoc.team/slcsp/)


### PR DESCRIPTION
# Notes

+ The copy on the Pre-work page says "Choose from one of these three exercises...", but there are four listed.
+ Remove number of exercises altogether to make this more future-proof against changes to the list of exercises. 😄 