### PR TITLE
Edit interviews page to be consistent with other GSA/TTS/18F guidance.

### DIFF
--- a/_pages/interviews.md
+++ b/_pages/interviews.md
@@ -78,7 +78,7 @@ Slack can be a helpful way to make sure an interview panel is moving smoothly, a
 
 ## Preparing for the interview
 
-- Before you begin each interview, **remind yourself to watch out for unconscious bias**. Remember that we’re especially susceptible to assume that underrepresented minorities — women, people of color, etc. — are less qualified than their white male counterparts. Be wary of “gut decisions” that aren’t backed up by specific behavior you’ve noted during the interview (this is one reason we ask behavioral questions, and try to take notes behaviorally).
+- Before you begin each interview, **remind yourself to be objective in your assessment**.  It is important that we conduct interviews objectively and you should be especially wary of any "gut decisions" that are not backed up by specific behavior you have noted in the process of the interview.  This is one reason why we ask behavioral questions and try to take notes behaviorally.
 
 - Spend some time becoming familiar with the candidates resume, which is always attached to calendar events.
 


### PR DESCRIPTION
This page previously contained race and sex/gender-related language in contradiction to other guidance that espouses a goal of removing discrimination or biases based on those categories.  I have modified the page to be consistent with those guidelines and objectives.

The page also previously referenced _unconscious bias_ and Brian Nosek, one of the co-authors of the original paper on the Implicit Association Test (IAT) purporting to measure unconscious bias, has made numerous requests to cease using that research as justification to create conscious behavioral changes.  These requests from Nosek are due to the link between IAT results and conscious behavior change not being supported by evidence, among other difficulties with the applications of the IAT.  I have modified the page accordingly while ensuring the text continues to encourage people to emphasize objectivity.