### PR TITLE
Nail down Ruby version to fix Circle build chain

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
   build:
     working_directory: ~/eng-hiring
     docker:
-       - image: circleci/ruby:2.7-node
+       - image: circleci/ruby:2.7.3-node
     environment:
       # fix encoding
       - LANG: C.UTF-8


### PR DESCRIPTION
Looks like Docker Hub pushed 2.7.4-node yesterday, and now CircleCI build chain is breaking for this repo. 
Nailing down Circle version to intentionally take ruby version updates with the rest of the repo.