### PR TITLE
Fix a typo in the workflow

### DIFF
--- a/.github/workflows/on_add_issue.yml
+++ b/.github/workflows/on_add_issue.yml
@@ -30,6 +30,6 @@ jobs:
         uses: actions/add-to-project@v0.4.0
         with:
           project-url: https://github.com/orgs/18F/projects/41
-          github-token: ${{ steps.app_token.outputs.token }
+          github-token: ${{ steps.app_token.outputs.token }}
           labeled: da-team
           label-operator: AND


### PR DESCRIPTION
Looks like one of the references wasn't closed. It'd be super neat if GitHub could do validation checks on action files even if it doesn't execute them so this could have come up sooner. 🤦🏻‍♂️ 